### PR TITLE
Add page__home class to more URLs

### DIFF
--- a/src/scripts/pages/home.js
+++ b/src/scripts/pages/home.js
@@ -16,7 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
     window.location.href === 'https://support.maxmind.com/hc/en-us' ||
     window.location.href === 'https://support.maxmind.com/hc/en-us/' ||
     window.location.href === 'https://maxmind.zendesk.com/hc/en-us' ||
-    window.location.href === 'https://maxmind.zendesk.com/hc/en-us/'
+    window.location.href === 'https://maxmind.zendesk.com/hc/en-us/' ||
+    window.location.href.startsWith('https://support.maxmind.com/hc/en-us?utm_source')
   ) {
     document.body.classList.add('page__home');
   }


### PR DESCRIPTION
On the newly created affiliate page, we have the URL: https://support.maxmind.com/hc/en-us?utm_source=sales_request&utm_medium=collateral&utm_campaign=inbound_sales&utm_id=affiliate_program_brochure. Currently, this has the sidebar even though it is on the home page, which is not desirable. This change ensures the sidebar does not show up on the home page when the URL starts with `https://support.maxmind.com/hc/en-us?utm_source`.